### PR TITLE
Added tags page.

### DIFF
--- a/tags/index.html
+++ b/tags/index.html
@@ -11,7 +11,7 @@ breadcrumbs: hidden
         });
 </script>
 
-<h1>Documents By Tag</h1>
+<h1>Pages By Tag</h1>
 
 {% for tag in site.tags %}
 {% capture tag_posts %}{% for post in tag[1] %}<li><a href="{{ post.url }}">{{ post.title }}</a></li>

--- a/tags/index.html
+++ b/tags/index.html
@@ -1,0 +1,27 @@
+---
+title: Tags
+layout: default
+breadcrumbs: hidden
+---
+<script type="text/javascript">
+        $(document).ready(function() {
+                        if(window.location.hash != "" && $("#tag-" + window.location.hash.substr(1)).length > 0) {
+                        $(".tag:not(#tag-" + window.location.hash.substr(1) + ")").hide();
+                }
+        });
+</script>
+
+<h1>Documents By Tag</h1>
+
+{% for tag in site.tags %}
+{% capture tag_posts %}{% for post in tag[1] %}<li><a href="{{ post.url }}">{{ post.title }}</a></li>
+{% endfor %}{% endcapture %}
+{% if tag_posts != "" %}
+<div class="tag" id="tag-{{ tag | first }}">
+<h3>{{ tag | first | capitalize }}</h3>
+<ul>
+{{ tag_posts }}
+</ul>
+</div>
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
First attempt at #20. Created a tags page that lists all the tags that currently have pages associated with them.

Link to the tags by linking to dev.iron.io/tags/#heroku, for example. I included some jQuery that will hide all the tags except for the one linked to.

Downside: tags and posts are sorted by date descending, and it would be a monumental hack for me to get them alphabetically sorting.

Other Note: I can easily filter this to show only articles, a specific product, or, really, anything else we want. That's why the markup is structured in such a funny way at the moment. If we decide we don't want to filter at all, I'll refactor into something a bit more elegant.
