### PR TITLE
Begin to make the idea of .worker more prominent.

### DIFF
--- a/worker/index.html
+++ b/worker/index.html
@@ -42,7 +42,7 @@ section: worker
 	<p><strong>Note:</strong> You only need to upload your code package <em>when your code changes</em>. Queuing tasks <em>does not</em> require you to upload the code package again.</p>
 </div>
 
-<p>The suggested way to do this is through a <span class="fixed-width">.worker</span> file. There's extensive <a href="/worker/reference/dotworker">documentation</a> for <span class="fixed-width">.worker</span> files, but the snippet below should be enough to get you started. Just save it as "<span class="fixed-width">firstworker.worker</span>" in the same directory as your code.</p>
+<p>The suggested way to do this is through a <span class="fixed-width">.worker</span> (pronounced "dotworker") file. There's extensive <a href="/worker/reference/dotworker">documentation</a> for <span class="fixed-width">.worker</span> files, but the snippet below should be enough to get you started. Just save it as "<span class="fixed-width">firstworker.worker</span>" in the same directory as your code.</p>
 
 {% highlight ruby %}
 runtime "ruby" # The runtime the code should be run under: ruby, python, php, or sh
@@ -51,6 +51,10 @@ exec "path/to/file.rb" # The file to execute when a task is queued. Your worker'
 
 file "config.json" # The path to a file to upload as a dependency of the worker; just leave this out if you don't have any dependencies.
 {% endhighlight %}
+
+<div class="alert">
+	<p><strong>Note:</strong> You should never have a file named <em>just</em> ".worker". Always use a unique, recognisable name&mdash;it's what your code package will be named. "helloworld.worker" will create a code package named "helloworld", "turnintoaunicorn.worker" will create a code package named "turnintoaunicorn", etc.</p>
+</div>
 
 <p>Once you've defined your worker and its dependencies with a <span class="fixed-width">.worker</span> file, you can upload it using the <a href="/worker/reference/cli">command line tool</a> for IronWorker. <strong>Note:</strong> You'll need to have Ruby 1.9+ installed to use the IronWorker CLI. After that, just run "<span class="fixed-width">gem install iron_worker_ng</span>" to get the tool.</p>
 

--- a/worker/reference/dotworker/index.md
+++ b/worker/reference/dotworker/index.md
@@ -11,8 +11,7 @@ breadcrumbs:
 
 We like to encourage our users to think of workers as independent chunks 
 of functionality, reusable building blocks that they can then build an 
-application out of. `.worker` files serve to reinforce this idea, by 
-allowing users to define their workers outside of their application code.
+application out of. `.worker` (pronounced dotworker) files serve to reinforce this idea, by allowing users to define their workers outside of their application code.
 
 `.worker` files are pretty easy to understand: their purpose is to construct 
 the code packages that are uploaded to the IronWorker cloud. This is done 
@@ -26,7 +25,11 @@ own self-contained units.
 ## Making a Worker File
 
 Writing a `.worker` file is simple: give it a recognisable name, then append 
-".worker" to the end.
+".worker" to the end. For example: `hello.worker` will create a code package named "hello".
+
+<div class="alert">
+<p><strong>Note:</strong> You should never have a file named ".worker". They should always be given a unique, recognisable name: "helloworld.worker", "sendmail.worker", "dosomethingawesome.worker", etc.</p>
+</div>
 
 ### Structure
 


### PR DESCRIPTION
Addresses #172. Adds some notes about the pronunciation of ".worker" to /worker and /worker/reference/dotworker. Also adds big, hard-to-miss notes that you can't just name a file ".worker".
