### PR TITLE
Changed css targeting for issue #234

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -49,7 +49,7 @@
   margin: 0;
 }
 
-.content-container .content a[href^="http"] {
+.content-container .content a[target="_blank"] {
   background: url(/images/external-link.png) no-repeat 100% 3px;
   padding-right: 14px;
   white-space: nowrap;


### PR DESCRIPTION
Links that do not target a new page no longer have the 'open in new tab' icon. This does not address the issue that there are many links that should link externally but don't.
