### PR TITLE
Add iron_go to all library lists and the Go language page.

### DIFF
--- a/cache/reference/libraries/index.md
+++ b/cache/reference/libraries/index.md
@@ -18,6 +18,7 @@ These are our official client libraries that use the IronCache <a href="/cache/r
 <li><a href="https://github.com/iron-io/iron_cache_python">Python</a></li>
 <li><a href="https://github.com/iron-io/iron_cache_dotnet">.NET</a></li>
 <li><a href="https://github.com/odeits/IronTools">.NET</a> (community-built; not official)</li>
+<li><a href="https://github.com/iron-io/iron_go">Go</a></li>
 </ul>
 </div>
 

--- a/mq/libraries/index.md
+++ b/mq/libraries/index.md
@@ -13,6 +13,7 @@ These are our official client libraries that use the IronMQ <a href="/mq/referen
 <ul>
 <li><a href="https://github.com/iron-io/iron_mq_ruby">Ruby</a></li>
 <li><a href="https://github.com/iron-io/iron_mq_go">Go</a></li>
+<li><a href="https://github.com/iron-io/iron_go">Go</a></li>
 <li><a href="https://github.com/iron-io/iron_mq_java">Java</a></li>
 <li><a href="https://github.com/iron-io/iron_mq_php">PHP</a></li>
 <li><a href="https://github.com/iron-io/iron_mq_python">Python</a></li>

--- a/mq/libraries/index.md
+++ b/mq/libraries/index.md
@@ -12,7 +12,6 @@ These are our official client libraries that use the IronMQ <a href="/mq/referen
 <div>
 <ul>
 <li><a href="https://github.com/iron-io/iron_mq_ruby">Ruby</a></li>
-<li><a href="https://github.com/iron-io/iron_mq_go">Go</a></li>
 <li><a href="https://github.com/iron-io/iron_go">Go</a></li>
 <li><a href="https://github.com/iron-io/iron_mq_java">Java</a></li>
 <li><a href="https://github.com/iron-io/iron_mq_php">PHP</a></li>

--- a/worker/languages/go/index.md
+++ b/worker/languages/go/index.md
@@ -15,7 +15,7 @@ Go Workers need to be compiled, then uploaded. Once they're uploaded to the
 IronWorker cloud, they can be invoked via a simple API to be put on the 
 processing queues immediately or scheduled to run at a later time&mdash;you only need to upload the worker again when the code changes. This article will walk you through the specifics of things, but you should be familiar with the [basics of IronWorker](/worker).
 
-**Note**: we don't use it for this walkthrough, but there's a great [unofficial library](https://github.com/manveru/go.iron) for working with the IronWorker API in Go. If working with raw HTTP requests doesn't sound like fun to you, check it out.
+**Note**: we don't use it for this walkthrough, but there's a great [library](https://github.com/iron-io/iron_go) for working with the IronWorker API in Go. If working with raw HTTP requests doesn't sound like fun to you, check it out.
 
 ## Quick Start
 


### PR DESCRIPTION
This fixes #221, but I'd like to hear back from @treeder about whether I should remove the link to iron_mq_go before it gets merged.
