### PR TITLE
couple more nitpicks

### DIFF
--- a/worker/languages/ruby/index.md
+++ b/worker/languages/ruby/index.md
@@ -116,7 +116,7 @@ Retrieving the payload in Ruby workers is a bit different&mdash;some of the
 clients take care of the dirty work for you. So while it's still the same 
 process&mdash;get the `-payload` argument passed to the script at runtime, 
 read the file it specifies, and parse the JSON contained within that file&mdash;
-the official client library takes care of that for you and let you just access 
+the official client library takes care of that for you and lets you just access
 the payload as a variable at runtime. Here's an example:
 
 In the upload script:

--- a/worker/languages/ruby/index.md
+++ b/worker/languages/ruby/index.md
@@ -119,7 +119,7 @@ read the file it specifies, and parse the JSON contained within that file&mdash;
 the official client library takes care of that for you and lets you just access
 the payload as a variable at runtime. Here's an example:
 
-In the upload script:
+In the task queuing script:
 {% highlight ruby %}
 require 'iron_worker_ng'
 


### PR DESCRIPTION
Took "upload" out of caption to be consistent with previous terminology:
- upload code packages to define worker
- queue up task for worker to process

The code block queues a task
