### PR TITLE
small changes

### DIFF
--- a/worker/languages/ruby/index.md
+++ b/worker/languages/ruby/index.md
@@ -174,7 +174,7 @@ The Ruby environment that the workers run in on IronWorker is as follows:
 <tbody>
 <tr>
 <td style="width: 25%;">Ruby Version</td>
-<td style="width: 75%;"><a href="http://www.ruby-lang.org/en/downloads/" title="Version 1.9.2p280">1.9.2p280</a></td>
+<td style="width: 75%;"><a href="http://www.ruby-lang.org/en/downloads/" title="Version 1.9.3p0">1.9.3p0</a></td>
 </tr>
 <tr>
 <td colspan="2" style="text-align: center; width: 100%;"><h4 style="padding: 0px;">Installed Gems</h4></td>

--- a/worker/reference/api/index.md
+++ b/worker/reference/api/index.md
@@ -116,10 +116,10 @@ Note that each request also requires a Project ID to specify which project the a
 **Example Authorization Header**:  
 Authorization: OAuth abc4c7c627376858
 
+**Note**: Be sure you have the correct case: it's **OAuth**, not Oauth.
+
 **Example Query with Parameters**:  
 GET https://<span class="variable host">worker-aws-us-east-1</span>.iron.io/2/projects/<span class="variable project_id">{Project ID}</span>/tasks?oauth=abc4c7c627376858
-
-**Note**: Be sure you have the correct case: it's **OAuth**, not Oauth.
 
 ## Requests
 

--- a/worker/reference/environment/index.md
+++ b/worker/reference/environment/index.md
@@ -97,7 +97,7 @@ The following is the default number of scheduled tasks. It should be sufficient 
 <b>Max Scheduled Tasks:</b> 100
 </div>
 
-Tip: A common mistake is to create scheduled jobs on a per user or per item basis. Instead, use scheduled jobs as master tasks that orchestrate activities around sets of users or items. When schedule tasks run, they can access databases to get a list of actions to perform and then queue up one or more workers to handle the set. View the [page on scheduling](/worker/scheduling) for more information on scheduling patterns and best practices.
+Tip: A common mistake is to create scheduled jobs on a per user or per item basis. Instead, use scheduled jobs as master tasks that orchestrate activities around sets of users or items. When scheduled tasks run, they can access databases to get a list of actions to perform and then queue up one or more workers to handle the set. View the [page on scheduling](/worker/scheduling) for more information on scheduling patterns and best practices.
 
 ## Minimum run_every Time
 


### PR DESCRIPTION
I ran a worker containing

``` ruby
puts "this is ruby #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
```

and got back 1.9.3-p0 so I updated the docs accordingly.

Also two other clarity/grammar changes.
