### PR TITLE
Fix copy-paste error in Get Push Status documentation.

### DIFF
--- a/mq/reference/api/index.md
+++ b/mq/reference/api/index.md
@@ -689,7 +689,7 @@ GET /projects/<span class="variable project_id">{Project ID}</span>/queues/<span
 
 * **Project ID**: The project these messages belong to.
 * **Queue Name**: The name of queue.
-* **Message ID**: The id of the message to delete.
+* **Message ID**: The id of the message to retrieve status for.
 
 ### Response
 {% highlight js %}


### PR DESCRIPTION
It looks like the documentation for "Get Push Status" was copied from
"Delete". This commit fixes the wording on the URL parameters.
