### PR TITLE
Fix header name and http method

### DIFF
--- a/mq/reference/push_queues/index.md
+++ b/mq/reference/push_queues/index.md
@@ -76,7 +76,7 @@ If you'd like to take more time to process messages, see 202 section below.
 If you'd like to take some time to process a message, more than the 60 second timeout, you must respond with HTTP status code 202.
 Be sure to set the "timeout" value when [posting your message](/mq/reference/api) to the maximum amount of time you'd like your processing to take.
 If you do not explicitly delete the message before the "timeout" has passed, the message will be retried.
-To delete the message, check the "Iron-Message" header and POST an empty request to that link.
+To delete the message, check the "Iron-Subscriber-Message-Url" header and send a DELETE request to that URL.
 
 ### Push Queue Headers
 


### PR DESCRIPTION
For acknowledging a push queue message that was 202'd, made header and http method the same as shown one section below.

Ran code to test this and found
- There is no "Iron-Message" header in the push request from IronMQ
- POSTing to value of "Iron-Subscriber-Message-Url" returned 404 and retries kept going
- DELETEing to value of "Iron-Subscriber-Message-Url" returned 200 and the retries stopped
