### PR TITLE
fixes documentation

### DIFF
--- a/mq/reference/api/index.md
+++ b/mq/reference/api/index.md
@@ -408,10 +408,6 @@ POST /projects/<span class="variable project_id">{Project ID}</span>/queues/<spa
 
 ##### Optional
 
-Parameters, related to Pull (regular) Queues:
-
-* **alerts**: An array of alerts hashes containing required "type", "direction", "queue", "trigger", and optional "buffer" fields. Maximum number of alerts is 5. See [Queue Alerts](/mq/reference/queue_alerts/) to learn more. To add, update or remove alerts see the <a href="#add_alerts_to_a_queue">add alerts</a>, <a href="#update_alerts_on_a_queue">update alerts</a> and <a href="#remove_alerts_from_a_queue">remove alerts</a>. Alerts does not work on [Push Queues](/mq/reference/push_queues/).
-
 The following parameters are all related to Push Queues.
 
 * **subscribers**: An array of subscriber hashes containing a required "url" field and an optional "headers" map for custom headers. This set of subscribers will replace the existing subscribers. See [Push Queues](/mq/reference/push_queues/) to learn more about types of subscribers. To add or remove subscribers, see the <a href="#add_subscribers_to_a_queue">add subscribers endpoint</a> or the <a href="#remove_subscribers_from_a_queue">remove subscribers endpoint</a>. The maximum is 64kb for JSON array of subscribers' hashes. See below for example JSON.


### PR DESCRIPTION
Removes `alerts` from POST queue info because it was never allowed to add alerts via this endpoint.
