### PR TITLE
replace .Net with .NET, remove redundant style, start second row in thum...

### DIFF
--- a/cache/reference/libraries/index.md
+++ b/cache/reference/libraries/index.md
@@ -16,10 +16,9 @@ These are our official client libraries that use the IronCache <a href="/cache/r
 		<li><a href="https://github.com/iron-io/iron_cache_ruby" target="_blank" data-lang="ruby">Ruby</a></li>
 		<li><a href="https://github.com/iron-io/iron_cache_php" target="_blank" data-lang="php">PHP</a></li>
 		<li><a href="https://github.com/iron-io/iron_cache_python" target="_blank" data-lang="python">Python</a></li>
-		<li><a href="https://github.com/iron-io/iron_cache_dotnet" target="_blank" data-lang="dotnet">.NET</a></li>
+		<li><a href="https://github.com/iron-io/iron_dotnet" target="_blank" data-lang="dotnet">.NET</a></li>
 		<li><a href="https://github.com/iron-io/iron_go" target="_blank" data-lang="go">Go</a></li>
     <li><a href="https://github.com/iron-io/iron_cache_rails" target="_blank" data-lang="rails">Rails</a></li>
-    <li><a href="https://github.com/iron-io/iron_dotnet" target="_blank" data-lang="dotnet">.Net</a></li>
 	</ul>
 </div>
 

--- a/css/application.css
+++ b/css/application.css
@@ -4927,10 +4927,6 @@ ul#architecture li {
   background: url(/images/libs/language_clojure.png) no-repeat 22px 12px;
 }
 
-.content-container .content .libs li a[data-lang="dotnet"] {
-  background: url(/images/libs/language_dotnet.png) no-repeat 22px 8px;
-}
-
 /*framework stlying*/
 .content-container .content .frameworks-row li {
   display:inline-block;

--- a/worker/libraries/index.md
+++ b/worker/libraries/index.md
@@ -15,11 +15,12 @@ These are our official client libraries that use the IronWorker <a href="/worker
 	<li><a href="https://github.com/iron-io/iron_worker_php" target="_blank" data-lang="php">PHP</a></li>
 	<li><a href="https://github.com/iron-io/iron_worker_python" target="_blank" data-lang="python">Python</a></li>
 	<li><a href="https://github.com/iron-io/iron_worker_java" target="_blank" data-lang="java">Java</a></li>
-	<li><a href="https://github.com/iron-io/iron_worker_node" target="_blank" data-lang="node">Node.JS</a></li>
+	<li style="clear:left;"><a href="https://github.com/iron-io/iron_worker_node" target="_blank" data-lang="node">Node.JS</a></li>
 	<li><a href="https://github.com/iron-io/iron_go" target="_blank" data-lang="go">Go</a></li>
-	<li><a href="https://github.com/iron-io/iron_dotnet" target="_blank" data-lang="dotnet">.Net</a></li>
+	<li><a href="https://github.com/iron-io/iron_dotnet" target="_blank" data-lang="dotnet">.NET</a></li>
 </ul>
 </div>
+<div style="clear: both;"><div/>
 
 ## Community Supported Client Libraries
 


### PR DESCRIPTION
replace .Net with .NET
remove redundant style
start second row in thumbs block of official libs
