### PR TITLE
Removing extra </div> that broke the layout

### DIFF
--- a/mq/reference/push_queues/index.md
+++ b/mq/reference/push_queues/index.md
@@ -66,7 +66,7 @@ To turn a queue into a push queue (or create one), POST to your queue endpoint w
 - subscribers - required - an array of hashes containing subscribers. eg: `{"url": "http://myserver.com/endpoint"}`.
 The maximum is 64kb for JSONify array of subscribers' hashes. **WARNING:** Do not use the following RFC 3986 Reserved Characters  within your in the naming of your subscriber endpoints.
   <p>! * ' ( ) ; : @ & = + $ , / ? # [ ]</p>
-</div>
+
 - push_type - multicast or unicast. Default is multicast. Set this to 'pull' to revert back to a pull queue.
 - retries - number of times to retry. Default is 3. Maximum is 100.
 - retries_delay - time in seconds between retries. Default is 60. Minimum is 3 and maximum is 86400 seconds.


### PR DESCRIPTION
The extra div closing tag is breaking the layout

http://dev.iron.io/mq/reference/push_queues/

![image](https://f.cloud.github.com/assets/71258/2342507/88b538c0-a4f8-11e3-88e1-9febe89d9f53.png)
