### PR TITLE
clearer explanation of npm certificate workaround

### DIFF
--- a/worker/languages/nodejs/index.md
+++ b/worker/languages/nodejs/index.md
@@ -8,11 +8,11 @@ breadcrumbs:
 ---
 
 <span class="notice-highlight">
-Notice -- For the NPM Certificate Error. Please use the following in your ".worker" file:
+Notice -- For the NPM Certificate Error. Please use the following in your ".worker" file, instead of <code>build "npm install"</code>:
 </span>
 
 ```js
-npm config set strict-ssl false; npm install --production
+build "npm config set strict-ssl false; npm install --production"
 ```
 <hr>
 


### PR DESCRIPTION
Currently, copy and pasting the explanation of the node certificate fix into the worker file causes build errors.

This updates the code to be copy/pasteable and more clear as to how to fix it.
