### PR TITLE
updating python documentation

### DIFF
--- a/worker/languages/python/index.md
+++ b/worker/languages/python/index.md
@@ -59,7 +59,7 @@ $ gem install iron_worker_ng
 You can download the Python client library, `iron_worker_python`,
 from [Github](https://github.com/iron-io/iron_worker_python)&mdash;note
 that you'll need the [iron_core_python](https://github.com/iron-io/iron_core_python) library installed, too.
-Users of pip or easy_install can simply use `pip install iron_worker` and `easy_install iron_worker`.
+Users of pip or easy_install can simply use `pip install iron-worker` and `easy_install iron-worker`.
 
 <h3 id="create_your_configuration_file">Create Your Configuration File</h3>
 


### PR DESCRIPTION
the pypi package has been moved to `iron-worker` from `iron_worker` took me a few minutes to find the new library.
