### PR TITLE
updated index.md to fix display bug

### DIFF
--- a/worker/languages/python/index.md
+++ b/worker/languages/python/index.md
@@ -32,7 +32,6 @@ This article will get you started writing Python workers, but you should be fami
         <li><a href="#payload_example">Payload Example</a></li>
         <li><a href="#exit_example">Exit Worker expicitly with an exit code</a></li>
         <li><a href="#environment">Environment</a></li>
-
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
fixed display bug in http python page of worker/languages that was causing </ul> and </li> tags to show up in the documentation http://dev.iron.io/worker/languages/python/.

screenshot of original:
https://www.dropbox.com/s/9gjchgr617q6zfy/Screenshot%202014-10-17%2015.59.13.png?dl=0

fixed:
https://www.dropbox.com/s/ej2zqh8785mfbqn/Screenshot%202014-10-17%2015.59.45.png?dl=0
