### PR TITLE
Correct the format of worker scheduling page

### DIFF
--- a/worker/scheduling/index.md
+++ b/worker/scheduling/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: IronWorker: Scheduling Tasks with Scheduler
+title: IronWorker&colon; Scheduling Tasks with Scheduler
 section: worker
 breadcrumbs:
   - ["Scheduling Tasks", "/scheduling"]


### PR DESCRIPTION
Fixed the format issue in http://dev.iron.io/worker/scheduling/ page
