### PR TITLE
Add Terraform MQ trial instructions

### DIFF
--- a/mq/on-premise/installation/index.md
+++ b/mq/on-premise/installation/index.md
@@ -13,7 +13,7 @@ section: mq-on-premise
   <h3>Getting Started</h3>
   <ul>
     <li><a href="#requirements">System Requirements</a></li>
-    <li><a href="#automatic_setup">Automatic Setup</a></li>
+    <li><a href="#automated">Automated Setup</a></li>
     <ul>
       <li><a href="#terraform">Terraform</a></li>
     </ul>
@@ -35,9 +35,7 @@ section: mq-on-premise
 * __CPU__ : 2+ CPU
 * __Storage__ : SSD Drive
 
-Yes, it will probably work on your laptop. Don't benchmark on your laptop :)
-
-<h2 id="automatic_setup">Automatic Setup</h2>
+<h2 id="automated">Automated Setup</h2>
 
 <h3 id="terraform">Terraform</h3>
 

--- a/mq/on-premise/installation/index.md
+++ b/mq/on-premise/installation/index.md
@@ -45,8 +45,8 @@ If you have an Amazon Web Services account, follow these instructions to launch 
 
 <ol>
   <li><a href="https://terraform.io/downloads.html">Download and install Terraform</a>. An introduction to Terraform can be found <a href="https://terraform.io/intro/">here</a>.</li>
-  <li>Download or `git clone` the IronMQ Terraform configuration from <a href="https://github.com/iron-io/enterprise/blob/master/trial_mq">this GitHub repository</a>.</li>
-  <li>Create a `terraform.tfvars.json` file with your credentials.  A sample configuration can be found <a href="https://github.com/iron-io/enterprise/blob/master/trial_mq/sample.tfvars.json">here</a></li>
+  <li>Download or `git clone` the IronMQ Terraform configuration from <a href="https://github.com/iron-io/enterprise/blob/master/terraform/ironmq">this GitHub repository</a>.</li>
+  <li>Create a `terraform.tfvars.json` file with your credentials.  A sample configuration can be found <a href="https://github.com/iron-io/enterprise/blob/master/terraform/ironmq/sample.tfvars.json">here</a></li>
   <li>Run `terraform plan -out=plan -var-file=terraform.tfvars.json`, review the plan, then run `terraform apply plan`.</li>
 </ol>
 

--- a/mq/on-premise/installation/index.md
+++ b/mq/on-premise/installation/index.md
@@ -33,8 +33,8 @@ If you have an Amazon Web Services account, follow these instructions to launch 
 
 <ol>
   <li><a href="https://terraform.io/downloads.html">Download and install Terraform</a>. An introduction to Terraform can be found <a href="https://terraform.io/intro/">here</a>.</li>
-  <li>Download or `git clone` the IronMQ Terraform configuration from <a href="https://github.com/iron-io/enterprise/blob/master/ironmq_trial">this GitHub repository</a>.</li>
-  <li>Create a `terraform.tfvars.json` file with your credentials.  A sample configuration can be found <a href="https://github.com/iron-io/enterprise/blob/master/sample.tfvars.json">here</a></li>
+  <li>Download or `git clone` the IronMQ Terraform configuration from <a href="https://github.com/iron-io/enterprise/blob/master/trial_mq">this GitHub repository</a>.</li>
+  <li>Create a `terraform.tfvars.json` file with your credentials.  A sample configuration can be found <a href="https://github.com/iron-io/enterprise/blob/master/trial_mq/sample.tfvars.json">here</a></li>
   <li>Run `terraform plan -out=plan -var-file=terraform.tfvars.json`, review the plan, then run `terraform apply plan`.</li>
 </ol>
 

--- a/mq/on-premise/installation/index.md
+++ b/mq/on-premise/installation/index.md
@@ -12,10 +12,13 @@ section: mq-on-premise
 <section id="toc">
   <h3>Getting Started</h3>
   <ul>
-    <li><a href="#terraform">Automatic Setup with Terraform</a></li>
+    <li><a href="#requirements">System Requirements</a></li>
+    <li><a href="#automatic_setup">Automatic Setup</a></li>
+    <ul>
+      <li><a href="#terraform">Terraform</a></li>
+    </ul>
     <li><a href="#manual">Manual Setup</a></li>
     <ul>
-      <li><a href="#requirements">Recommended System Requirements</a></li>
       <li><a href="#download">Download</a></li>
       <li><a href="#install">Install</a></li>
       <li><a href="#create_new_user_account">Setup New User Account</a></li>
@@ -25,7 +28,18 @@ section: mq-on-premise
   </ul>
 </section>
 
-<h2 id="terraform">Automatic Setup with Terraform</h2>
+<h2 id="requirements">Minimum System Requirements</h2>
+
+* __OS__: Docker installed
+* __RAM__ : 8GB+
+* __CPU__ : 2+ CPU
+* __Storage__ : SSD Drive
+
+Yes, it will probably work on your laptop. Don't benchmark on your laptop :)
+
+<h2 id="automatic_setup">Automatic Setup</h2>
+
+<h3 id="terraform">Terraform</h3>
 
 Terraform is an infrastructure deployment tool which can be used to automatically launch IronMQ.
 
@@ -41,15 +55,6 @@ If you have an Amazon Web Services account, follow these instructions to launch 
 <h2 id="manual">Manual Setup</h2>
 
 If you would like to manually set up IronMQ instead, follow the instructions below.
-
-<h2 id="requirements">Recommended Minimum System Requirements</h2>
-
-* __OS__: Docker installed
-* __RAM__ : 8GB+
-* __CPU__ : 2+ CPU
-* __Storage__ : SSD Drive
-
-Yes, it will probably work on your laptop. Don't benchmark on your laptop :)
 
 <h2 id="download">Download</h2>
 

--- a/mq/on-premise/installation/index.md
+++ b/mq/on-premise/installation/index.md
@@ -12,22 +12,35 @@ section: mq-on-premise
 <section id="toc">
   <h3>Getting Started</h3>
   <ul>
-    <li><a href="#requirements">Recommended System Requirements</a></li>
-    <li><a href="#download">Download</a></li>
-    <li><a href="#install">Install</a></li>
-    <li><a href="#create_new_user_account">Setup New User Account</a></li>
-    <li><a href="#start">Client lib and API docs</a></li>
-    <li><a href="#custom_config">Custom Configuration</a></li>
+    <li><a href="#terraform">Automatic Setup with Terraform</a></li>
+    <li><a href="#manual">Manual Setup</a></li>
+    <ul>
+      <li><a href="#requirements">Recommended System Requirements</a></li>
+      <li><a href="#download">Download</a></li>
+      <li><a href="#install">Install</a></li>
+      <li><a href="#create_new_user_account">Setup New User Account</a></li>
+      <li><a href="#start">Client lib and API docs</a></li>
+      <li><a href="#custom_config">Custom Configuration</a></li>
+    </ul>
   </ul>
 </section>
 
+<h2 id="terraform">Automatic Setup with Terraform</h2>
 
-<h2 id="download">Download</h2>
+Terraform is an infrastructure deployment tool which can be used to automatically launch IronMQ.
 
-```
-$ docker pull iron/mq
-$ docker pull iron/auth
-```
+If you have an Amazon Web Services account, follow these instructions to launch IronMQ with Terraform.
+
+<ol>
+  <li><a href="https://terraform.io/downloads.html">Download and install Terraform</a>. An introduction to Terraform can be found <a href="https://terraform.io/intro/">here</a>.</li>
+  <li>Download or `git clone` the IronMQ Terraform configuration from <a href="https://github.com/iron-io/enterprise/blob/master/ironmq_trial">this GitHub repository</a>.</li>
+  <li>Create a `terraform.tfvars.json` file with your credentials.  A sample configuration can be found <a href="https://github.com/iron-io/enterprise/blob/master/sample.tfvars.json">here</a></li>
+  <li>Run `terraform plan -out=plan -var-file=terraform.tfvars.json`, review the plan, then run `terraform apply plan`.</li>
+</ol>
+
+<h2 id="manual">Manual Setup</h2>
+
+If you would like to manually set up IronMQ instead, follow the instructions below.
 
 <h2 id="requirements">Recommended Minimum System Requirements</h2>
 
@@ -37,6 +50,13 @@ $ docker pull iron/auth
 * __Storage__ : SSD Drive
 
 Yes, it will probably work on your laptop. Don't benchmark on your laptop :)
+
+<h2 id="download">Download</h2>
+
+```
+$ docker pull iron/mq
+$ docker pull iron/auth
+```
 
 <h2 id="install">Install and Start</h2>
 


### PR DESCRIPTION
This adds a section at the top of the On Premise Installation page explaining how to use Terraform to deploy IronMQ.
