### PR TITLE
Task scheduling optional parameters: +timeout, -delay, -task_delay

### DIFF
--- a/worker/reference/api/index.md
+++ b/worker/reference/api/index.md
@@ -1036,8 +1036,6 @@ Optionally, each object in the array can specify the following properties:
 * **run_times**: The number of times a task will run.
 * **priority**: The priority queue to run the task in. Valid values are 0, 1, and 2. Task priority determines how much time a task may sit in queue. Higher values means tasks spend less time in the queue once they come off the schedule. Access to priorities depends on your selected IronWorker plan [see plans](http://www.iron.io/products/worker/pricing). You must have access to higher priority levels in your chosen plan or your priority will automatically default back to 0.  The standard/default priority is 0.
 * **timeout**: The maximum runtime of your task in seconds. No task can exceed 3600 seconds (60 minutes). The default is 3600 but can be set to a shorter duration.
-* **delay**: The number of seconds to delay before scheduling the tasks. Default is 0.
-* **task_delay**: The number of seconds to delay before actually queuing the task. Default is 0.
 * **cluster**: cluster name ex: "high-mem" or "dedicated".  This is a premium feature for customers for customers to have access to more powerful or custom built worker solutions. Dedicated worker clusters exist for users who want to reserve a set number of workers just for their queued tasks. If not set default is set to  "default" which is the public IronWorker cluster.
 
 

--- a/worker/reference/api/index.md
+++ b/worker/reference/api/index.md
@@ -1035,6 +1035,9 @@ Optionally, each object in the array can specify the following properties:
 * **end_at**: The time tasks will stop being queued. Should be a time or datetime.
 * **run_times**: The number of times a task will run.
 * **priority**: The priority queue to run the task in. Valid values are 0, 1, and 2. Task priority determines how much time a task may sit in queue. Higher values means tasks spend less time in the queue once they come off the schedule. Access to priorities depends on your selected IronWorker plan [see plans](http://www.iron.io/products/worker/pricing). You must have access to higher priority levels in your chosen plan or your priority will automatically default back to 0.  The standard/default priority is 0.
+* **timeout**: The maximum runtime of your task in seconds. No task can exceed 3600 seconds (60 minutes). The default is 3600 but can be set to a shorter duration.
+* **delay**: The number of seconds to delay before scheduling the tasks. Default is 0.
+* **task_delay**: The number of seconds to delay before actually queuing the task. Default is 0.
 * **cluster**: cluster name ex: "high-mem" or "dedicated".  This is a premium feature for customers for customers to have access to more powerful or custom built worker solutions. Dedicated worker clusters exist for users who want to reserve a set number of workers just for their queued tasks. If not set default is set to  "default" which is the public IronWorker cluster.
 
 

--- a/worker/scheduling/index.md
+++ b/worker/scheduling/index.md
@@ -56,8 +56,6 @@ Optionally, each object in the array can specify the following properties:
 * **run_times**: The number of times a task will run.
 * **priority**: The priority queue to run the task in. Valid values are 0, 1, and 2. Task priority determines how much time a task may sit in queue. Higher values means tasks spend less time in the queue once they come off the schedule. Access to priorities depends on your selected IronWorker plan [see plans](http://www.iron.io/products/worker/pricing). You must have access to higher priority levels in your chosen plan or your priority will automatically default back to 0.  The standard/default priority is 0.
 * **timeout**: The maximum runtime of your task in seconds. No task can exceed 3600 seconds (60 minutes). The default is 3600 but can be set to a shorter duration.
-* **delay**: The number of seconds to delay before scheduling the tasks. Default is 0.
-* **task_delay**: The number of seconds to delay before actually queuing the task. Default is 0.
 * **cluster**: cluster name ex: "high-mem" or "dedicated".  This is a premium feature for customers for customers to have access to more powerful or custom built worker solutions. Dedicated worker clusters exist for users who want to reserve a set number of workers just for their queued tasks. If not set default is set to  "default" which is the public IronWorker cluster.
 
 


### PR DESCRIPTION
Added task scheduling optional parameters description to worker api reference: timeout, delay, task_delay .
