### PR TITLE
trying to get some docker goodness [WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM razic/bundler
+FROM ruby
 
-RUN mkdir -p /iron/docs
-ADD Gemfile /iron/docs/Gemfile
-WORKDIR /iron/docs
+RUN mkdir -p /irondocs
+ADD . /irondocs
+WORKDIR /irondocs
+
 RUN bundle install
-
-ENTRYPOINT ["bundle"]

--- a/dockerserve.sh
+++ b/dockerserve.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "running 'bundle exec jekyll serve' in docker"
+CMD="bundle exec jekyll serve"
+docker run --net=host -p 4000:4000 -v $PWD:/irondocs -w /irondocs iron/docs $CMD


### PR DESCRIPTION
after this

``` bash
> docker build -t iron/docs .
> ./dockerserve.sh
```

there's still an error

``` bash
/usr/local/bundle/gems/liquid-2.6.1/lib/liquid/htmltags.rb:43: warning:
duplicated key at line 46 ignored: "index0"
/usr/local/bundle/gems/execjs-2.5.0/lib/execjs/runtimes.rb:48:in
`autodetect': Could not find a JavaScript runtime. See
https://github.com/rails/execjs for a list of available runtimes.
(ExecJS::RuntimeUnavailable)
    from /usr/local/bundle/gems/execjs-2.5.0/lib/execjs.rb:5:in
`<module:ExecJS>'
    from /usr/local/bundle/gems/execjs-2.5.0/lib/execjs.rb:4:in `<top
(required)>'
    from
/usr/local/bundle/gems/coffee-script-2.4.1/lib/coffee_script.rb:1:in
`require'
    from
/usr/local/bundle/gems/coffee-script-2.4.1/lib/coffee_script.rb:1:in
`<top (required)>'
    from
/usr/local/bundle/gems/coffee-script-2.4.1/lib/coffee-script.rb:1:in
`require'
    from
/usr/local/bundle/gems/coffee-script-2.4.1/lib/coffee-script.rb:1:in
`<top (required)>'
    from
/usr/local/bundle/gems/jekyll-coffeescript-1.0.1/lib/jekyll-coffeescript
.rb:2:in `require'
    from
/usr/local/bundle/gems/jekyll-coffeescript-1.0.1/lib/jekyll-coffeescript
.rb:2:in `<top (required)>'
    from
/usr/local/bundle/gems/jekyll-2.4.0/lib/jekyll/deprecator.rb:46:in
`require'
    from
/usr/local/bundle/gems/jekyll-2.4.0/lib/jekyll/deprecator.rb:46:in
`block in gracefully_require'
    from
/usr/local/bundle/gems/jekyll-2.4.0/lib/jekyll/deprecator.rb:44:in
`each'
    from
/usr/local/bundle/gems/jekyll-2.4.0/lib/jekyll/deprecator.rb:44:in
`gracefully_require'
    from /usr/local/bundle/gems/jekyll-2.4.0/lib/jekyll.rb:141:in `<top
(required)>'
    from /usr/local/bundle/gems/jekyll-2.4.0/bin/jekyll:6:in `require'
    from /usr/local/bundle/gems/jekyll-2.4.0/bin/jekyll:6:in `<top
(required)>'
    from /usr/local/bundle/bin/jekyll:16:in `load'
    from /usr/local/bundle/bin/jekyll:16:in `<main>'
```

still need to figure that out. not urgent but it'd be nice to have this all docker-ey
