### PR TITLE
Clean up section on multiple worker environments (iron --env)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,41 @@
-# Installation
+Iron.io Dev Center Documentation
+================================
 
-1. run `bundle install`
+The [Dev Center docs] are a [Jekyll] project. Refer to Jekyll's official docs and [Using Jekyll with GitHub Pages][1] for complete help. We give a quick start guide below.
 
-# Launching
+[Dev Center docs]: http://dev.iron.io/
+[Jekyll]: http://jekyllrb.com/
+[1]: https://help.github.com/articles/using-jekyll-with-pages/
 
-1. Go to project directory
-2. Type `bundle exec jekyll serve` # do not use --auto!  jekyll breaks
-3. Open browser at http://localhost:4000/
+Installation
+------------
 
-# Development
+1. Get [Bundler], the Ruby dependency manager, if you don't have it already.
+2. `$ git clone https://github.com/iron-io/docs.git && cd docs`
+3. `$ bundle install`
 
-1. go to project directory
-2. jekyll serve --watch (this will auto reload any changes)
-3. for more information on jekyll  http://jekyllrb.com/docs/home/
+[Bundler]: http://bundler.io/
 
-More info: https://help.github.com/articles/using-jekyll-with-pages
+Launching
+---------
 
-# Development using Cloud9 (http://c9.io)
+1. In the project directory, run `bundle exec jekyll serve`
+2. Open your browser to <http://localhost:4000/>
 
-1. Fork https://github.com/iron-io/docs to your github account
-2. Login (or signup) at http://c9.io using github
-3. Click on 'docs' under 'PROJECTS ON GITHUB' in the left menu
-4. Click the green 'CLONE TO EDIT' button
-5. In the terminal use the command: jekyll serve --watch --port $PORT
+Development
+-----------
 
-When you are done making your awesome edits, git commit && git push, then go back to github and do a pull request.  
+In the project directory, run `bundle exec jekyll serve --watch`. This will auto-reload as you make changes to files.
+
+Development using Cloud9 (http://c9.io)
+---------------------------------------
+
+1. Fork https://github.com/iron-io/docs to your GitHub account.
+2. Log in (or sign up) at <http://c9.io> using GitHub.
+3. Click on 'docs' under 'PROJECTS ON GITHUB' in the left menu.
+4. Click the green 'CLONE TO EDIT' button.
+5. In the terminal, run `jekyll serve --watch --port $PORT`.
+
+When you are finished making your awesome edits, `git commit && git push`, then go back to GitHub to open a pull request.
+
 Easy as pie and you never even had to leave your browser!

--- a/worker/cli/index.md
+++ b/worker/cli/index.md
@@ -14,7 +14,7 @@ The Iron.io command line tool will help you interact with the IronWorker API to 
     <li><a href="#installing">Installing</a></li>
     <li><a href="#configuration">Configuration</a></li>
     <li><a href="#creating__uploading_code_packages">Creating and Uploading Code Packages</a></li>
-    <li><a href="#upload_with_multiple_environments">Upload with Multiple Environments</a></li>
+    <li><a href="#uploading_to_multiple_environments">Uploading to Multiple Environments</a></li>
     <li><a href="#queuing_tasks">Queuing Tasks</a></li>
     <li><a href="#scheduling_tasks">Scheduling Tasks</a></li>
     <li><a href="#retrieving_a_tasks_log">Retrieving a Task's Log</a></li>
@@ -93,20 +93,11 @@ iron worker upload --retries 5 --retries-delay 10 ...
 There are additional options available to the upload command; you can find
 a list of them by running `iron worker upload --help`. All of these options can be mixed and matched at will to easily create very complex, specific behaviors.
 
-<h2 id="upload_with_multiple_environments">Upload with Multiple Environments</h2>
+<h2 id="uploading_to_multiple_environments">Uploading to Multiple Environments</h2>
 
-It is common to want to use IronWorker across many different development environments.
+It is a common and good practice to deploy applications to multiple environments, such as staging and production for quality assurance of releases. IronWorker supports workflows like this by using separate Iron.io projects, and the CLI has a convenient feature to assist.
 
-When uploading your worker you can specify an environment via the ** --env **.
-
-```sh
-iron --env test       worker upload --zip helloworker.zip --name helloworker iron/images:ruby-2.1 ruby rubies.rb
-iron --env production worker upload --zip helloworker.zip --name helloworker iron/images:node-0.10 node nodes.js
-```
-
-We reccomend you create seperate projects for each development environment.
-Below is an example of a typical iron.json with multiple environments iron.json into multiple development environments via different project id's and tokens.
-
+You can set up a project for each of your desired environments (say, "MyApp Production"), then include each project in your `iron.json` configuration nested under an environment nickname:
 
 ```js
 {
@@ -127,6 +118,15 @@ Below is an example of a typical iron.json with multiple environments iron.json 
     "project_id": "000000000000000000000004"
   }
 }
+```
+
+These nicknames (`production`, `staging`) can be whatever you like, so they can be shorter than the projects' descriptive names in the web HUD.
+
+Now you can upload your code packages to each environment by specifying the `--env` option to the CLI:
+
+```sh
+iron --env test       worker upload --zip hello-rb.zip --name helloworker-rb iron/images:ruby-2.1 ruby myworker.rb
+iron --env production worker upload --zip hello-js.zip --name helloworker-js iron/images:node-0.10 node myworker.js
 ```
 
 <h2 id="queuing_tasks">Queuing Tasks</h2>


### PR DESCRIPTION
This section had some grammatical issues and upon fixing them it seemed like the section could benefit from some rewriting. I thought it clearer to explain that you first need separate projects created, then the multi-project `iron.json` config format that enables the `iron --env` CLI option, and _then_ finally show how the commands work once the setup is ready.

There's an extra commit in here that (I think) improves formatting and information in the project README—sorry if that clouds the focus of a review but since they're relatively minor changes I lumped them together. Can split that commit off to another branch if you prefer.
