### PR TITLE
Fix typo in iron.json: 'schema' -> 'scheme'

### DIFF
--- a/_includes/configuration.md
+++ b/_includes/configuration.md
@@ -160,7 +160,7 @@ It is useful to quickly change your host in cases where your region has gone dow
   "project_id": "PROJECT ID HERE",
   "token": "YOUR TOKEN HERE"
   "port":443,
-  "schema": "https",
+  "scheme": "https",
   "host":"mq-rackspace-ord.iron.io"
 }
 {% endhighlight %}


### PR DESCRIPTION
Signed-off-by: Mikko Koivunalho mikko.koivunalho@iki.fi
