### PR TITLE
Fix API output example on function "stacks"

### DIFF
--- a/worker/reference/api/index.md
+++ b/worker/reference/api/index.md
@@ -1217,7 +1217,5 @@ The response will be a JSON object.
 Sample:
 
 ```js
-{
-  ["scala-2.9","ruby-2.1","ruby-1.9","python-3.2","python-2.7","php-5.4","node-0.10","java-1.7","mono-3.0","mono-2.10"]
-}
+["scala-2.9","ruby-2.1","ruby-1.9","python-3.2","python-2.7","php-5.4","node-0.10","java-1.7","mono-3.0","mono-2.10"]
 ```


### PR DESCRIPTION
Fix API output example

Example run:
$ curl -H "Authorization: OAuth ***" -H "Content-Type: application/json" https://worker-aws-us-east-1.iron.io:443/2/stacks
["go-1.4","scala-2.9","ruby-2.1","ruby-1.9","ruby-1.8","python-3.2","python-2.7","php-5.4","php-5.6","node-0.10","node-0.11","node-0.12","java-1.7","mono-3.0","crawler","selenium","newrelic","phantom-1.9","phantom-2.0","phantom-1.9-b","phantom-2.0-b","ffmpeg-2.3","php-5.5","java-1.8","mono-3.6","mono-2.10"]

Signed-off-by: Mikko Johannes Koivunalho mikko.koivunalho@iki.fi
