### PR TITLE
adding docker registry docs for on-premise installation

### DIFF
--- a/worker/on-premise/docker-registry.md
+++ b/worker/on-premise/docker-registry.md
@@ -6,15 +6,23 @@ breadcrumbs:
   - ['On-Premise', '/on-premise']
 ---
 
-This will allow you to use a custom Docker Registry with an Iron On-Premise installation.
+This will allow you to use a custom Docker Registry with an Iron On-Premise
+installation.
 
-There are two types of Docker registries, insecure and secure. The one which you configure depends on your situation. Due to limitations on controlling domains and certificates in an On Premise environment, we are only able to create an insecure registry.
+There are two types of Docker registries, insecure and secure. The one which you
+configure depends on your situation. Due to limitations on controlling domains
+and certificates in an On Premise environment, we are only able to create an
+insecure registry.
 
 # Installation
 
-The only difference in workflow between an insecure registry and a secure registry is that you'll need to whitelist the registry from your local Docker daemon.
+The only difference in workflow between an insecure registry and a secure
+registry is that you'll need to whitelist the registry from your local Docker
+daemon.
 
-To set up a registry with the On Premise Installer, simply include a `[docker-registry]` host in your `./config/inventory.ini` with a proper server IP and the Docker registry will be installed on that server.
+To set up a registry with the On Premise Installer, simply include a
+`[docker-registry]` host in your `./config/inventory.ini` with a proper server
+IP and the Docker registry will be installed on that server.
 
 ```
 [docker-registry]
@@ -25,7 +33,9 @@ This registry will serve on port `6000`.
 
 # Usage
 
-You will need to alter your local Docker before being able to push images to this registry. This is a little different depending on your OS -- please see [here](https://docs.docker.com/registry/insecure/) for how to set it up.
+You will need to alter your local Docker before being able to push images to
+this registry. This is a little different depending on your OS -- please see
+[here](https://docs.docker.com/registry/insecure/) for how to set it up.
 
 You can then Docker push `hello` to your insecure registry.
 
@@ -45,4 +55,5 @@ You can then queue tasks to run like this.
 iron worker queue test
 ```
 
-For more information on the Docker Registry and how to create and push images, please see [this TL;DR](https://docs.docker.com/registry/#/tl-dr) from docker.
+For more information on the Docker Registry and how to create and push images,
+please see [this TL;DR](https://docs.docker.com/registry/#/tl-dr) from docker.

--- a/worker/on-premise/docker-registry.md
+++ b/worker/on-premise/docker-registry.md
@@ -1,0 +1,48 @@
+---
+title: IronWorker On-Premise Docker Registry
+layout: default
+section: worker
+breadcrumbs:
+  - ['On-Premise', '/on-premise']
+---
+
+This will allow you to use a custom docker registry with an Iron On-Premise installation.
+
+There are two types of docker registries, insecure and secure. The one which you configure depends on your situation. However, due to limitations on controlling domains and certificates in an On Premise environment, we are only able to create an insecure registry.
+
+# Installation
+
+The only difference in workflow between an insecure registry and a secure registry is that you'll need to whitelist the registry from your local docker daemon.
+
+To set up a registry with the On Premise Installer, simply include a `[docker-registry]` host in your `./config/inventory.ini` with a proper server IP and the docker registry will be installed on that server.
+
+```
+[docker-registry]
+192.168.x.x
+```
+
+This registry will serve on port `6000`.
+
+# Usage
+
+You will need to alter your local docker before being able to push images to this registry. This is a little different depending on your OS -- please see [here](https://docs.docker.com/registry/insecure/) for how to set it up.
+
+You can then docker push `hello` to your insecure registry
+
+```
+docker push 192.168.x.x:6000/hello
+```
+
+Then register this image with Iron
+
+```
+iron register -name test 192.168.x.x:6000/hello
+```
+
+You can then queue tasks to run like this
+
+```
+iron worker queue test
+```
+
+For more information on the docker registry and how to create and push images, please see [this TL;DR](https://docs.docker.com/registry/#/tl-dr) from docker.

--- a/worker/on-premise/docker-registry.md
+++ b/worker/on-premise/docker-registry.md
@@ -6,15 +6,15 @@ breadcrumbs:
   - ['On-Premise', '/on-premise']
 ---
 
-This will allow you to use a custom docker registry with an Iron On-Premise installation.
+This will allow you to use a custom Docker Registry with an Iron On-Premise installation.
 
-There are two types of docker registries, insecure and secure. The one which you configure depends on your situation. However, due to limitations on controlling domains and certificates in an On Premise environment, we are only able to create an insecure registry.
+There are two types of Docker registries, insecure and secure. The one which you configure depends on your situation. Due to limitations on controlling domains and certificates in an On Premise environment, we are only able to create an insecure registry.
 
 # Installation
 
-The only difference in workflow between an insecure registry and a secure registry is that you'll need to whitelist the registry from your local docker daemon.
+The only difference in workflow between an insecure registry and a secure registry is that you'll need to whitelist the registry from your local Docker daemon.
 
-To set up a registry with the On Premise Installer, simply include a `[docker-registry]` host in your `./config/inventory.ini` with a proper server IP and the docker registry will be installed on that server.
+To set up a registry with the On Premise Installer, simply include a `[docker-registry]` host in your `./config/inventory.ini` with a proper server IP and the Docker registry will be installed on that server.
 
 ```
 [docker-registry]
@@ -25,24 +25,24 @@ This registry will serve on port `6000`.
 
 # Usage
 
-You will need to alter your local docker before being able to push images to this registry. This is a little different depending on your OS -- please see [here](https://docs.docker.com/registry/insecure/) for how to set it up.
+You will need to alter your local Docker before being able to push images to this registry. This is a little different depending on your OS -- please see [here](https://docs.docker.com/registry/insecure/) for how to set it up.
 
-You can then docker push `hello` to your insecure registry
+You can then Docker push `hello` to your insecure registry.
 
 ```
 docker push 192.168.x.x:6000/hello
 ```
 
-Then register this image with Iron
+Then register this image with Iron.
 
 ```
 iron register -name test 192.168.x.x:6000/hello
 ```
 
-You can then queue tasks to run like this
+You can then queue tasks to run like this.
 
 ```
 iron worker queue test
 ```
 
-For more information on the docker registry and how to create and push images, please see [this TL;DR](https://docs.docker.com/registry/#/tl-dr) from docker.
+For more information on the Docker Registry and how to create and push images, please see [this TL;DR](https://docs.docker.com/registry/#/tl-dr) from docker.

--- a/worker/on-premise/index.md
+++ b/worker/on-premise/index.md
@@ -11,6 +11,7 @@ This is how the pieces fit together:
 ![Architecture Diagram](on-prem-parts.png)
 
 * [QuickStart Installation](/worker/on-premise/quickstart)
-* [Load Testing](/worker/on-premise/quickstart)
+* [Load Testing](/worker/on-premise/load-testing)
 * [Scaling](/worker/on-premise/scaling)
 * [Manual Installation](/worker/on-premise/manual)
+* [Docker Registry Setup](/worker/on-premise/docker-registry)


### PR DESCRIPTION
This explains how to set up a docker registry with the on-prem installer. This is an optional step in the on-prem installation. 
