### PR TITLE
cache: updating expires_in from 30days to 7days

### DIFF
--- a/cache/reference/api/index.md
+++ b/cache/reference/api/index.md
@@ -318,7 +318,7 @@ Each item object should contain the following keys:
 
 ##### Optional
 
-* **expires_in**: How long in seconds to keep the item in the cache before it is deleted. Maximum is 2,592,000 seconds (30 days).
+* **expires_in**: How long in seconds to keep the item in the cache before it is deleted. Maximum is 604,800 seconds (7 days).
 * **replace**: If set to true, only set the item if the item is already in the cache. If the item is not in the cache, do not create it.
 * **add**: If set to true, only set the item if the item is not already in the cache. If the item is in the cache, do not overwrite it.
 * **cas**: If set, the new item will only be placed in the cache if there is an existing item with a matching key and cas value. An item's cas value is automatically generated and is included when the item is <a href="#get_an_item_from_a_cache" title="Get an Item from a Cache">retrieved</a>.


### PR DESCRIPTION
We recently updated contracts and have lowered cache maximum item time from 30days to 7days.

Please contact @srogerf for any questions.
