### PR TITLE
Add clojure client for IronCache

### DIFF
--- a/cache/reference/libraries/index.md
+++ b/cache/reference/libraries/index.md
@@ -35,5 +35,6 @@ These are some unofficial client libraries that use the IronCache <a href="/cach
   <li><a href="https://github.com/skitsanos/IronCache-Client" target="_blank">ActionScript 3.0 - IronCache-Client</a> by <a href="https://github.com/skitsanos">Evgenios Skitsanos</a></li>
   <li><a href="https://github.com/jrutheiser/Codeigniter-Iron.io" target="_blank">PHP - Codeigniter-Iron.io</a> by <a href="https://github.com/jrutheiser" target="_blank">jrutheiser</a></li>
   <li><a href="https://metacpan.org/release/IO-Iron" target="_blank">Perl - IO::Iron</a> by <a href="https://metacpan.org/author/MIKKOI" target="_blank">Mikko Koivunalho</a></li>
+  <li><a href="https://github.com/kolotaev/iron-cache" target="_blank">Clojure - iron-cache</a> by <a href="https://github.com/kolotaev" target="_blank">Egor Kolotaev</a></li>
 </ul>
 </div>


### PR DESCRIPTION
Hi!
I've written a clojure client library for IronCache: [iron-cache](https://github.com/kolotaev/iron-cache)
It has a decent test suite, but anyways it'd be nice to check its sanity against a real Iron cache project, so getting any sort of developer's demo project on iron.io is highly appreciated.